### PR TITLE
Auto detect controls.

### DIFF
--- a/src/utils/gpxParser.js
+++ b/src/utils/gpxParser.js
@@ -85,6 +85,22 @@ class AnalyzeRoute {
         }
     }
 
+    parseCoursePoints = (routeData, type) =>
+        (type === "rwgps" ?
+        routeData[routeData.type]['course_points'] :
+        [])
+
+    isControl = (coursePoint) => {
+        const controlRegexp = /control|rest stop|regroup/i;
+        return coursePoint.t === 'Control' || coursePoint.n.match(controlRegexp);
+    }
+
+    controlFromCoursePoint = (coursePoint) =>
+        ({name:coursePoint.n, duration:1, distance:Math.round((coursePoint.d*kmToMiles)/1000)})
+
+    extractControlPoints = (routeData, type) =>
+        this.parseCoursePoints(routeData, type).filter(point => this.isControl(point)).map(point => this.controlFromCoursePoint(point))
+
     parseRouteStream = (routeData, type) =>
         (type === "rwgps" ?
         routeData[routeData.type]['track_points'].map(point => ({ lat: point.y, lon: point.x, elevation: point.e, dist: point.d })) :

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -75,6 +75,10 @@ export const controlsMeaningfullyDifferent = (controls1, controls2) => {
     )
 }
 
+export const extractControlsFromRoute = (routeData) => {
+  return gpxParser.extractControlPoints(routeData, 'rwgps');
+}
+
 export const stringIsOnlyNumeric = string => string.match(/^[0-9]*$/) !== null
 export const stringIsOnlyDecimal = string => string.match(/^[0-9.]*$/) !== null
 


### PR DESCRIPTION
Parse the list of course points in the ridewithgps data, and look for either course points of type control or whose description contains control, regroup, or rest stop. Add those to the control point list with
default one minute stopping time. Only do this if no control points
were provided.

Also stop trying to load controls from cookie,
now that we no longer save that cookie.